### PR TITLE
Fix link to config file in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,4 +185,4 @@ THE SOFTWARE.
 
 
 [1]: https://github.com/1aN0rmus/TekDefense-Automater
-[2]: https://raw.githubusercontent.com/HurricaneLabs/machinae/master/machinae.yml
+[2]: https://github.com/HurricaneLabs/machinae/raw/master/machinae.yml


### PR DESCRIPTION
Due to this being a private repo and the raw files requiring JWT auth, you  have to use this link for the config file, otherwise the page will just say "Not found"
