### PR TITLE
HTTP Basic Auth implementation and passivetotal integration

### DIFF
--- a/machinae.yml
+++ b/machinae.yml
@@ -1051,3 +1051,170 @@ threatcrowd_ip_report:
     - key: 'hashes'
       pretty_name: Known Malware Hash
       match_all: true
+
+passivetotal_pdns:
+  name: PassiveTotal Passive DNS
+  default: False
+  otypes:
+    - fqdn
+    - ipv4
+  json:
+    request:
+      url: 'https://api.passivetotal.org/v2/dns/passive'
+      auth: passivetotal
+      params:
+        query: '{target}'
+      method: get
+      headers:
+        Accept: application/json
+      ignored_status_codes:
+        - 401
+    results:
+      - key: results
+        format: as_list
+        pretty_name: Results
+        multi_match:
+          keys:
+            - key: resolve
+      - key: queryValue
+        pretty_name: Query Value
+
+passivetotal_whois:
+  name: PassiveTotal Whois
+  default: False
+  otypes:
+    - fqdn
+  json:
+    request:
+      url: 'https://api.passivetotal.org/v2/whois'
+      auth: passivetotal
+      params:
+        query: '{target}'
+      method: get
+      headers:
+        Accept: application/json
+      ignored_status_codes:
+        - 401
+    results:
+      - key: registryUpdatedAt
+        pretty_name: Registry Updated At
+      - key: domain
+        pretty_name: Domain
+      - key: billing
+        pretty_name: Billing
+      - key: zone
+        pretty_name: Zone
+      - key: nameServers
+        pretty_name: Name Servers
+      - key: registered
+        pretty_name: Registered
+      - key: lastLoadedAt
+        pretty_name: Last Loaded At
+      - key: whoisServer
+        pretty_name: Whois Server
+      - key: contactEmail
+        pretty_name: Contact Email
+      - key: admin
+        pretty_name: Admin
+      - key: expiresAt
+        pretty_name: Expires At
+      - key: registrar
+        pretty_name: Registrar
+      - key: tech
+        pretty_name: Tech
+      - key: registrant
+        pretty_name: Registrant
+
+passivetotal_sslcert:
+  name: PassiveTotal SSL Certificate History
+  default: False
+  otypes:
+    - ipv4
+  json:
+    request:
+      url: 'https://api.passivetotal.org/v2/ssl-certificate/history'
+      auth: passivetotal
+      params:
+        query: '{target}'
+      method: get
+      headers:
+        Accept: application/json
+      ignored_status_codes:
+        - 401
+    results:
+      - key: results
+        multi_match:
+          keys:
+            - key: sha1
+              pretty_name: Sha1
+            - key: firstSeen
+              pretty_name: First Seen
+            - key: ipAddresses
+              pretty_name: Ip Addresses
+            - key: lastSeen
+              pretty_name: Last Seen
+        pretty_name: Results
+
+passivetotal_components:
+  name: PassiveTotal Components
+  default: False
+  otypes:
+    - fqdn
+  json:
+    request:
+      url: 'https://api.passivetotal.org/v2/host-attributes/components'
+      auth: passivetotal
+      params:
+        query: '{target}'
+      method: get
+      headers:
+        Accept: application/json
+      ignored_status_codes:
+        - 401
+    results:
+      - key: results
+        multi_match:
+          keys:
+          - key: category
+            pretty_name: Category
+          - key: hostname
+            pretty_name: Hostname
+          - key: lastSeen
+            pretty_name: Last Seen
+          - key: firstSeen
+            pretty_name: First Seen
+          - key: label
+            pretty_name: Label
+        pretty_name: Results
+
+passivetotal_trackers:
+  name: PassiveTotal Trackers
+  default: False
+  otypes:
+    - fqdn
+  json:
+    request:
+      url: 'https://api.passivetotal.org/v2/host-attributes/trackers'
+      auth: passivetotal
+      params:
+        query: '{target}'
+      method: get
+      headers:
+        Accept: application/json
+      ignored_status_codes:
+        - 401
+    results:
+      - key: results
+        multi_match:
+          keys:
+          - key: hostname
+            pretty_name: Hostname
+          - key: attributeType
+            pretty_name: Type
+          - key: attributeValue
+            pretty_name: Value
+          - key: lastSeen
+            pretty_name: Last Seen
+          - key: firstSeen
+            pretty_name: First Seen
+        pretty_name: Results

--- a/src/machinae/cmd.py
+++ b/src/machinae/cmd.py
@@ -37,6 +37,7 @@ class MachinaeCommand:
                             )
             ap.add_argument("-q", "--quiet", dest="verbose", default=True, action="store_false")
             ap.add_argument("-s", "--sites", default="default")
+            ap.add_argument("-a", "--auth")
             ap.add_argument("targets", nargs=argparse.REMAINDER)
 
             modes = ap.add_mutually_exclusive_group()
@@ -85,6 +86,10 @@ class MachinaeCommand:
 
     @property
     def results(self):
+        creds = None
+        if self.args.auth and os.path.isfile(self.args.auth):
+            with open(self.args.auth) as auth_f:
+                creds = utils.safe_load(auth_f.read())
         for target_info in self.targets:
             (target, otype, _) = target_info
 
@@ -95,7 +100,7 @@ class MachinaeCommand:
 
                 site_conf["target"] = target
                 site_conf["verbose"] = self.args.verbose
-                scraper = Site.from_conf(site_conf)  # , verbose=self.verbose)
+                scraper = Site.from_conf(site_conf, creds=creds)  # , verbose=self.verbose)
 
                 try:
                     with stopit.SignalTimeout(15, swallow_exc=False):

--- a/src/machinae/sites/__init__.py
+++ b/src/machinae/sites/__init__.py
@@ -7,8 +7,9 @@ class Site(object):
     _session = None
     _kwargs = None
 
-    def __init__(self, conf):
+    def __init__(self, conf, creds=None):
         self.conf = conf
+        self.creds = creds
 
     def kwargs_getter(self):
         return self._kwargs

--- a/src/machinae/sites/base.py
+++ b/src/machinae/sites/base.py
@@ -93,10 +93,8 @@ class HttpSite(Site):
             kwargs["data"] = data
 
         # HTTP Basic Auth
-        if conf.get("auth") and self.creds:
-            creds = self.creds.get(conf["auth"])
-            if creds:
-                kwargs["auth"] = (creds.get("username"), creds.get("password"))
+        if conf.get("auth") and self.creds and self.creds.get(conf["auth"]):
+            kwargs["auth"] = tuple(self.creds[conf["auth"]])
 
         # Auto decompress
         if conf.get("decompress", False):

--- a/src/machinae/sites/base.py
+++ b/src/machinae/sites/base.py
@@ -92,6 +92,12 @@ class HttpSite(Site):
         if len(data) > 0:
             kwargs["data"] = data
 
+        # HTTP Basic Auth
+        if conf.get("auth") and self.creds:
+            creds = self.creds.get(conf["auth"])
+            if creds:
+                kwargs["auth"] = (creds.get("username"), creds.get("password"))
+
         # Auto decompress
         if conf.get("decompress", False):
             kwargs["hooks"] = {"response": self.unzip_content}


### PR DESCRIPTION
Using the --auth/-a flag to pass in an authentication config will allow you to use HTTP basic auth for configs you specify.

Example:

```
$ machinae -a auth.yml passivetotal.org
...
$ cat machinae.yml
...
passivetotal_trackers:
  name: PassiveTotal Trackers
  default: False
  otypes:
    - fqdn
  json:
    request:
      url: 'https://api.passivetotal.org/v2/host-attributes/trackers'
      auth: passivetotal
...
$ cat auth.yml
passivetotal:
  - '<username>'
  - '<api key>'
```