### PR TITLE
Closing recent issues

### DIFF
--- a/machinae.yml
+++ b/machinae.yml
@@ -255,13 +255,13 @@ telize:
     - key: isp
       pretty_name: GeoIP ISP
 freegeoip:
-  name: freegeoip.net
+  name: freegeoip.io
   otypes:
     - ipv4
     - fqdn
   json:
     request:
-      url: https://freegeoip.net/json/{target}
+      url: https://freegeoip.io/json/{target}
     results:
     - key: country_code
       pretty_name: GeoIP Country Code

--- a/machinae.yml
+++ b/machinae.yml
@@ -254,6 +254,39 @@ telize:
       pretty_name: GeoIP ASN
     - key: isp
       pretty_name: GeoIP ISP
+maxmind:
+  name: MaxMind GeoIP2 Precision
+  otypes:
+    - ipv4
+  json:
+    request:
+      url: https://geoip.maxmind.com/geoip/v2.1/insights/{target}
+      auth: maxmind
+    results:
+    - key: country.iso_code
+      pretty_name: MaxMind Country Code
+    - key: country.names.en
+      pretty_name: MaxMind Country
+    - key: subdivisions
+      multi_match:
+        keys:
+          - iso_code
+      pretty_name: MaxMind Region Code
+    - key: subdivisions
+      multi_match:
+        keys:
+          - names.en
+      pretty_name: MaxMind Region
+    - key: city.names.en
+      pretty_name: MaxMind City
+    - key: postal.code
+      pretty_name: MaxMind Zip Code
+    - key: location.latitude
+      pretty_name: MaxMind Latitude
+    - key: location.longitude
+      pretty_name: MaxMind Longitude
+    - key: location.time_zone
+      pretty_name: MaxMind Timezone
 freegeoip:
   name: freegeoip.io
   otypes:

--- a/src/machinae/sites/__init__.py
+++ b/src/machinae/sites/__init__.py
@@ -7,9 +7,10 @@ class Site(object):
     _session = None
     _kwargs = None
 
-    def __init__(self, conf, creds=None):
+    def __init__(self, conf, creds=None, proxies=None):
         self.conf = conf
         self.creds = creds
+        self.proxies = proxies
 
     def kwargs_getter(self):
         return self._kwargs

--- a/src/machinae/sites/base.py
+++ b/src/machinae/sites/base.py
@@ -11,7 +11,12 @@ import pytz
 import relatime
 import requests
 from tzlocal import get_localzone
-from requests.packages.urllib3 import exceptions
+try:
+    from requests.packages.urllib3 import exceptions
+except ImportError:
+    # Apparently, some linux distros strip the packages out of requests
+    # I'm not going to tell you what I think of that, just going to deal with it
+    from urllib3 import exceptions
 
 from . import Site
 

--- a/src/machinae/sites/base.py
+++ b/src/machinae/sites/base.py
@@ -27,6 +27,8 @@ class HttpSite(Site):
         if self._session is None:
             self._session = requests.Session()
             self._session.headers.update({"User-Agent": "Vor/1.0 (Like CIF/2.0)"})
+            if self.proxies:
+                self._session.proxies = self.proxies
         return self._session
 
     @staticmethod


### PR DESCRIPTION
Closes #12 
- Add `-H/--http-proxy` command line flag for HTTP proxies
- Respect `http_proxy`/`https_proxy` in addition to normal `HTTP_PROXY`/`HTTPS_PROXY` env variables

Closes #18 
- Add try/except for ImportError on `requests.packages.urllib3`

Closes #20 
- Update `freegeoip.net` site to use `freegeoip.io`
- Add `MaxMind GeoIP2 Precision Insights` site