### PR TITLE
Update machinae.yml for Reputation Authority compatibility

### DIFF
--- a/machinae.yml
+++ b/machinae.yml
@@ -539,7 +539,7 @@ reputation_authority:
       url: 'http://www.reputationauthority.org/lookup.php?ip={target}'
       method: get
     results:
-      - regex: 'bsnd.+<(\d{1,3}/\d{1,3})'
+      - regex: '>(\d{1,3}\/\d{1,3})'
         values:
           - ra_score
         pretty_name: Reputation Authority Score


### PR DESCRIPTION
Reputation Authority changed their page elements at some point. That change broke machinae support.