### PR TITLE
Add observable to json output

### DIFF
--- a/src/machinae/outputs.py
+++ b/src/machinae/outputs.py
@@ -121,6 +121,7 @@ class JsonGenerator(MachinaeOutput):
                 output = dict()
                 output["site"] = item.site_info["name"]
                 output["results"] = dict()
+                output["observable"] = target
 
                 if hasattr(item, "error_info"):
                     output["results"] = {"error_info": str(item.error_info)}


### PR DESCRIPTION
The json output does not have a key for the observable. This makes it difficult to parse the results in a meaningful way.