### PR TITLE
Add rudimentary time parsing for json sites

### DIFF
--- a/src/machinae/sites/json.py
+++ b/src/machinae/sites/json.py
@@ -10,6 +10,7 @@ from dateutil.parser import parse
 
 from .base import HttpSite
 
+from relatime import timeParser
 
 class JsonApi(HttpSite):
     @staticmethod
@@ -165,6 +166,15 @@ class JsonApi(HttpSite):
                     rex = re.compile(onlyif["regex"], re.I)
                     if not rex.search(value):
                         continue
+                # Check for maxage key in onlyif. If it exists, parse it as Splunk relative time syntax and compare to parsed input "value"
+                elif "maxage" in onlyif:
+                    age=parse(value)
+                    if not onlyif["maxage"].startswith("-"):  # Assume we want dates in the past
+                        print('\033[91m' + 'WARNING: maxage must be prepended with "-" Please correct this in your configuration file.' + '\033[0m')
+                        onlyif["maxage"] = "-%s" % onlyif["maxage"]
+                    ageout=timeParser(onlyif["maxage"]).replace(tzinfo=None)
+                    if age < ageout:
+                        continue                        
                 else:
                     if not bool(value):
                         continue


### PR DESCRIPTION
Extends "onlyif" filtering with new "maxage" option, a splunk relative time syntax to limit ioc age by time.