### PR TITLE
Switch to a less-abandoned magic module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(readMeDir, 'README.md'), encoding='utf-8') as readFile:
     long_desc = readFile.read()
 
 
-VERSION = '1.4.10'
+VERSION = '1.4.11'
 
 setup(
     name='machinae',
@@ -33,7 +33,7 @@ setup(
         'html5lib',
         'relatime',
         'tzlocal',
-        'filemagic',
+        'python-magic',
         'feedparser',
         'defang',
     ],

--- a/src/machinae/sites/base.py
+++ b/src/machinae/sites/base.py
@@ -41,8 +41,7 @@ class HttpSite(Site):
     def unzip_content(r, *args, **kwargs):
         content = r.content
 
-        with magic.Magic(flags=magic.MAGIC_MIME_TYPE) as m:
-            mime = m.id_buffer(content)
+        mime = magic.from_buffer(content, mime=True)
 
         if mime == "application/zip":
             zip_buffer = io.BytesIO(content)


### PR DESCRIPTION
filemagic hasn't been updated in a decade and is (at least in my experience) does a pretty bad job finding libmagic. python-magic works better, so I'm switching Machinae over to use that instead. 